### PR TITLE
Cleanup release workflow and fix firefox-signed file name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      EXT_NAME: WikiTideDebug
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -29,9 +31,8 @@ jobs:
           jq 'del(.background.service_worker)' dist/firefox/manifest.json > dist/firefox/manifest.tmp.json
           mv dist/firefox/manifest.tmp.json dist/firefox/manifest.json
           web-ext build --source-dir=dist/firefox --overwrite-dest --artifacts-dir=dist/firefox
-          for f in dist/firefox/*.zip; do
-            mv "$f" "${f%.zip}.xpi"
-          done
+          VERSION=$(jq -r '.version' dist/firefox/manifest.json)
+          mv dist/firefox/*.zip dist/firefox/$EXT_NAME-$VERSION.xpi
 
       - name: Build & Sign Firefox XPI
         env:
@@ -57,10 +58,9 @@ jobs:
             echo "Signing failed, probably version already exists. Skipping signed XPI."
             rm -f dist/firefox-signed/*.xpi
           else
-            # Rename signed XPI to include "-signed"
-            for f in dist/firefox-signed/*.xpi; do
-              mv "$f" "${f%.xpi}-signed.xpi"
-            done
+            # Rename signed XPI to include the actual extension name and "-signed"
+            VERSION=$(jq -r '.version' manifest.json)
+            mv dist/firefox-signed/*.xpi dist/firefox-signed/$EXT_NAME-$VERSION-signed.xpi
           fi
 
       - name: Build Chrome CRX and ZIP
@@ -70,19 +70,25 @@ jobs:
           # Remove Firefox-specific fields from manifest
           jq 'del(.background.scripts, .browser_specific_settings)' dist/chrome/manifest.json > dist/chrome/manifest.tmp.json
           mv dist/chrome/manifest.tmp.json dist/chrome/manifest.json
+          VERSION=$(jq -r '.version' dist/chrome/manifest.json)
+
           web-ext build --source-dir=dist/chrome --overwrite-dest --artifacts-dir=dist/chrome
+          mv dist/chrome/*.zip dist/chrome/$EXT_NAME-$VERSION.zip
+
           # Write secret key to file
           echo "${{ secrets.CRX_KEY }}" > dist/chrome/key.pem
-          VERSION=$(jq -r '.version' dist/chrome/manifest.json)
-          crx3 pack dist/chrome --output dist/chrome/wikitidedebug-$VERSION.crx --key dist/chrome/key.pem
-          mv web-extension.crx dist/chrome/wikitidedebug-$VERSION.crx
+
+          crx3 pack dist/chrome \
+            --output dist/chrome/$EXT_NAME-$VERSION.crx \
+            --key dist/chrome/key.pem
+
+          mv web-extension.crx dist/chrome/$EXT_NAME-$VERSION.crx
 
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION=$(jq -r '.version' manifest.json)
-          REPO=$(basename $GITHUB_REPOSITORY)
           TAG="v$VERSION"
 
           if gh release view "$TAG" >/dev/null 2>&1; then
@@ -102,6 +108,6 @@ jobs:
 
             gh release create "$TAG" \
               $FILES \
-              --title "$REPO $VERSION" \
-              --notes "Automated release of $REPO version $VERSION for Firefox (unsigned + signed if available) and Chrome."
+              --title "$EXT_NAME $VERSION" \
+              --notes "Automated release of $EXT_NAME version $VERSION for Firefox (unsigned + signed if available) and Chrome."
           fi

--- a/manifest.json
+++ b/manifest.json
@@ -1,32 +1,33 @@
 {
-    "manifest_version": 3,
-    "name": "WikiTideDebug",
-    "description": "Injects 'X-WikiTide-Debug' header to HTTP requests.",
-    "version": "3.2.0",
-    "icons": {
-        "512": "logo.png"
-    },
-    "action": {
-        "default_title": "X-WikiTide-Debug",
-        "default_popup": "popup.html"
-    },
-    "background": {
-        "service_worker": "service-worker.js",
-        "scripts": [ "service-worker.js" ],
-        "type": "module"
-    },
-    "permissions": [
-        "alarms",
-        "storage",
-        "tabs",
-        "declarativeNetRequest"
-    ],
-    "host_permissions": [ "<all_urls>" ],
-    "browser_specific_settings": {
-        "gecko": {
-            "id": "wikitidedebug@wikitide.org",
-            "strict_min_version": "115.0",
-            "update_url": "https://raw.githubusercontent.com/miraheze/WikiTideDebug/refs/heads/main/update.json"
-        }
-    }
+	"manifest_version": 3,
+	"name": "WikiTideDebug",
+	"description": "Injects 'X-WikiTide-Debug' header to HTTP requests.",
+	"author": "Universal Omega",
+	"version": "3.3.0",
+	"icons": {
+		"512": "logo.png"
+	},
+	"action": {
+		"default_title": "X-WikiTide-Debug",
+		"default_popup": "popup.html"
+	},
+	"background": {
+		"service_worker": "service-worker.js",
+		"scripts": [ "service-worker.js" ],
+		"type": "module"
+	},
+	"permissions": [
+		"alarms",
+		"storage",
+		"tabs",
+		"declarativeNetRequest"
+	],
+	"host_permissions": [ "<all_urls>" ],
+	"browser_specific_settings": {
+		"gecko": {
+			"id": "wikitidedebug@wikitide.org",
+			"strict_min_version": "115.0",
+			"update_url": "https://raw.githubusercontent.com/miraheze/WikiTideDebug/refs/heads/main/update.json"
+		}
+	}
 }

--- a/update.json
+++ b/update.json
@@ -1,12 +1,16 @@
 {
-  "addons": {
-    "wikitidedebug@wikitide.org": {
-      "updates": [
-        {
-          "version": "3.2.0",
-          "update_link": "https://github.com/miraheze/WikiTideDebug/releases/download/v3.2.0/afeb7fde9f5646488f49-3.2.0-signed.xpi"
-        }
-      ]
-    }
-  }
+	"addons": {
+		"wikitidedebug@wikitide.org": {
+			"updates": [
+				{
+					"version": "3.2.0",
+					"update_link": "https://github.com/miraheze/WikiTideDebug/releases/download/v3.2.0/afeb7fde9f5646488f49-3.2.0-signed.xpi"
+				},
+				{
+					"version": "3.3.0",
+					"update_link": "https://github.com/miraheze/WikiTideDebug/releases/download/v3.3.0/WikiTideDebug-3.3.0-signed.xpi"
+				}
+			]
+		}
+	}
 }

--- a/update.json
+++ b/update.json
@@ -3,12 +3,8 @@
     "wikitidedebug@wikitide.org": {
       "updates": [
         {
-          "version": "3.1.0",
-          "update_link": "https://github.com/miraheze/WikiTideDebug/releases/download/v3.1.0/wikitidedebug-3.1.0.xpi"
-        },
-        {
           "version": "3.2.0",
-          "update_link": "https://github.com/miraheze/WikiTideDebug/releases/download/v3.2.0/wikitidedebug-3.2.0.xpi"
+          "update_link": "https://github.com/miraheze/WikiTideDebug/releases/download/v3.2.0/afeb7fde9f5646488f49-3.2.0-signed.xpi"
         }
       ]
     }


### PR DESCRIPTION
Also use signed packages in update.json, and make update.json and manifest.json use tabs rather than spaces.